### PR TITLE
Ensure debugger_test_parser tests are run during github actions workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,10 @@ jobs:
 # Be sure the debugger tests DO NOT run in parallel.
 # Each test attaches a debugger to the test process so there
 # can not be another debugger attached to the current test process.
-    - name: Run full test suite
-      run: cargo test --tests -- --test-threads=1
+    - name: Run debugger_test test suite
+      run: cargo test --package debugger_test -- --test-threads=1
+    - name: Run debugger_test_parser test suite
+      run: cargo test --package debugger_test_parser --manifest-path debugger_test_parser\Cargo.toml
 
   rustfmt:
     name: rustfmt

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ The `#[debugger_test]` proc macro attribute has 3 required meta items which all 
 3. expected_statements
 
 The `debugger` meta item expects the name of a supported debugger. Currently the only supported debugger is `cdb`.
+This crate will try to find the specified debugger, first by testing if it is on the `PATH`. If the debugger is
+not found, this crate will search the default installation directory for the debugger. Specifying an exact path
+for which debugger to use is not currently supported.
 
 The `commands` meta item expects a string of a debugger command to run. To run multiple commands, separate each
 command by the new line character (`\n`).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For example:
 
 ```rust
 #[inline(never)]
-pub fn __break() { }
+fn __break() { }
 
 #[debugger_test(
     debugger = "cdb",
@@ -30,7 +30,7 @@ g"#,
 pattern:test\.exe .*\.natvis
 a = 0n10
     "#)]
-pub fn test() {
+fn test() {
     let a = 10;
     __break();
 }
@@ -93,7 +93,7 @@ the test is unique. In the example above, the proc macro attribute will generate
 
 ```rust
 #[test]
-pub fn test__cdb() {
+fn test__cdb() {
     .....
     test();
     .....

--- a/debugger_test_parser/src/lib.rs
+++ b/debugger_test_parser/src/lib.rs
@@ -23,6 +23,20 @@ pub fn parse(debugger_output: String, expected_contents: Vec<&str>) -> anyhow::R
         .lines()
         .map(|line| line.trim())
         .collect::<Vec<&str>>();
+
+    // Trim whitespace at the beginning and end of expected contents.
+    let expected_contents = expected_contents
+        .iter()
+        .filter_map(|line| {
+            let str = line.trim();
+            match str.is_empty() {
+                false => Some(str),
+                true => None,
+            }
+        })
+        .map(|line| line.trim())
+        .collect::<Vec<&str>>();
+
     let mut index = 0;
 
     for expected in expected_contents {

--- a/debugger_test_parser/tests/test.rs
+++ b/debugger_test_parser/tests/test.rs
@@ -1,7 +1,7 @@
 use debugger_test_parser::parse;
 
 /// Verify that a test failed with a specific error message.
-pub fn verify_expected_failure(result: anyhow::Result<()>, expected_err_msg: &str) {
+fn verify_expected_failure(result: anyhow::Result<()>, expected_err_msg: &str) {
     let error = result
         .expect_err(format!("Expected error message missing: `{}`.", expected_err_msg).as_str());
     assert_eq!(expected_err_msg, format!("{error}"));
@@ -9,7 +9,7 @@ pub fn verify_expected_failure(result: anyhow::Result<()>, expected_err_msg: &st
 
 /// Test parsing empty debugger output.
 #[test]
-pub fn test_parse_empty_output() {
+fn test_parse_empty_output() {
     let output = String::from("");
     let expected_contents = Vec::with_capacity(0);
     parse(output, expected_contents).expect("able to parse output.");
@@ -18,7 +18,7 @@ pub fn test_parse_empty_output() {
 /// Test parsing debugger output for a single command.
 /// No expected content.
 #[test]
-pub fn test_parse_output_command() {
+fn test_parse_output_command() {
     let output = String::from(
         r#"
     dv
@@ -35,7 +35,7 @@ pub fn test_parse_output_command() {
 /// Test parsing a single debugger output.
 /// Verify expected content.
 #[test]
-pub fn test_verify_output_command() {
+fn test_verify_output_command() {
     let output = String::from(
         r#"
     dv
@@ -49,10 +49,27 @@ pub fn test_verify_output_command() {
     parse(output, expected_contents).expect("able to parse output.");
 }
 
+#[test]
+fn test_trim_expected_contents() {
+    let output = String::from(
+        r#"
+    dv
+        var1 = 0
+        var2 = { len = 3 }
+        var3 = { struct }
+    "#,
+    );
+
+    let expected_contents = vec![
+        "        var1 = 0"
+    ];
+    parse(output, expected_contents).expect("able to parse output.");
+}
+
 /// Test parsing debugger output for mutliple commands.
 /// Verify expected content.
 #[test]
-pub fn test_verify_output_multiple_commands() {
+fn test_verify_output_multiple_commands() {
     let output = String::from(
         r#"
     .nvlist
@@ -81,7 +98,7 @@ pub fn test_verify_output_multiple_commands() {
     );
 
     let expected_contents = vec![
-        r#"pattern:a.exe \(embedded NatVis ".*foo\.natvis"\)"#,
+        r#"pattern:a\.exe \(embedded NatVis ".*foo\.natvis"\)"#,
         "point_a          : (0, 0) [Type: foo::Point]",
         "[x]              : 0 [Type: int]",
         "person           : \"Person A\" is 10 years old. [Type: foo::Person]",
@@ -93,7 +110,7 @@ pub fn test_verify_output_multiple_commands() {
 /// Test expected content not found in debugger output due to incorrect ordering.
 /// Parsing fails.
 #[test]
-pub fn test_err_expected_string_not_found() {
+fn test_err_expected_string_not_found() {
     let output = String::from(
         r#"
     .nvlist
@@ -133,7 +150,7 @@ pub fn test_err_expected_string_not_found() {
 /// Test expected pattern not found in debugger output due to incorrect ordering.
 /// Parsing fails.
 #[test]
-pub fn test_err_expected_pattern_not_found() {
+fn test_err_expected_pattern_not_found() {
     let output = String::from(
         r#"
     .nvlist
@@ -166,14 +183,14 @@ pub fn test_err_expected_pattern_not_found() {
         r#"pattern:a\.exe \(embedded NatVis ".*foo\.natvis"\)"#,
     ];
 
-    let expected_err_msg = "Unable to find expected content in the debugger output. Found 0 matches for pattern: `a.exe \\(embedded NatVis \".*foo\\.natvis\"\\)`";
+    let expected_err_msg = "Unable to find expected content in the debugger output. Found 0 matches for pattern: `a\\.exe \\(embedded NatVis \".*foo\\.natvis\"\\)`";
     verify_expected_failure(parse(output, expected_contents), expected_err_msg);
 }
 
 /// Test expected pattern is not a valid regex.
 /// Parsing fails.
 #[test]
-pub fn test_err_expected_pattern_not_valid() {
+fn test_err_expected_pattern_not_valid() {
     let output = String::from(
         r#"
     .nvlist

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -140,7 +140,7 @@ pub fn get_debugger(debugger_type: &DebuggerType) -> anyhow::Result<Debugger> {
     not(target_os = "windows"),
     ignore = "test only runs on windows platforms."
 )]
-pub fn test_find_cdb() {
+fn test_find_cdb() {
     let result = find_cdb();
     assert!(result.is_ok());
 
@@ -157,7 +157,7 @@ pub fn test_find_cdb() {
     not(target_os = "windows"),
     ignore = "test only runs on windows platforms."
 )]
-pub fn test_get_debugger() {
+fn test_get_debugger() {
     let debugger_type = DebuggerType::Cdb;
 
     let result = get_debugger(&debugger_type);
@@ -169,7 +169,7 @@ pub fn test_get_debugger() {
 }
 
 #[test]
-pub fn test_debugger_type_from_str() {
+fn test_debugger_type_from_str() {
     assert!(DebuggerType::from_str("cdb").is_ok());
 
     let gdb_debugger_type = DebuggerType::from_str("gdb");

--- a/src/debugger_script.rs
+++ b/src/debugger_script.rs
@@ -27,7 +27,7 @@ pub fn create_debugger_script(fn_name: &String, debugger_commands: &Vec<&str>) -
 }
 
 #[test]
-pub fn test_debugger_script_empty() {
+fn test_debugger_script_empty() {
     let test_name = String::from("test1");
     let debugger_commands = vec![];
     let debugger_script = create_debugger_script(&test_name, &debugger_commands);
@@ -43,7 +43,7 @@ qd
 }
 
 #[test]
-pub fn test_debugger_script() {
+fn test_debugger_script() {
     let test_name = String::from("test1");
     let debugger_commands = vec!["dv", "g", ".nvlist"];
     let debugger_script = create_debugger_script(&test_name, &debugger_commands);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub fn debugger_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut debugger_test_fn = proc_macro::TokenStream::from(quote!(
         #[test]
         #cfg_attr
-        pub fn #test_fn_ident() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        fn #test_fn_ident() -> std::result::Result<(), Box<dyn std::error::Error>> {
             use std::io::Read;
             use std::io::Write;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,15 +1,15 @@
 use debugger_test::debugger_test;
 
 #[inline(never)]
-pub fn __break() {}
+fn __break() {}
 
 #[debugger_test(debugger = "cdb", commands = "", expected_statements = "")]
-pub fn test_empty_commands() {
+fn test_empty_commands() {
     __break();
 }
 
 #[debugger_test(debugger = "cdb", commands = ".nvlist", expected_statements = "")]
-pub fn test_no_expectations() {
+fn test_no_expectations() {
     __break();
 }
 
@@ -34,7 +34,7 @@ b = 0n25
 a = 0n5
 b = 0n10"#
 )]
-pub fn test_commands_with_expectations() {
+fn test_commands_with_expectations() {
     let mut a = 0;
     __break();
 


### PR DESCRIPTION
The tests for the `debugger_test_parser` crate were not being run during the github actions workflow. Ensure these tests are also run.

There was a bug where the beginning and ending whitespace of each expected statement was not being trimmed to match the debugger output content. Fix the bug and ensure the whitespace is trimmed and add a test case for this bug.