### PR TITLE
Bump the version of the debugger_test_parser crate and downgrade the edition to 2018

### DIFF
--- a/debugger_test_parser/Cargo.toml
+++ b/debugger_test_parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "debugger_test_parser"
-version = "0.1.1"
-edition = "2021"
+version = "0.1.2"
+edition = "2018"
 description = """
 Provides a library for parsing the output of a debugger and verifying the contents.
 """


### PR DESCRIPTION
A lot of the crates that this crate should be used for are still targeting the 2018 Rust edition. Keeping this at 2021 will cause it to be unusable in those crates.