### PR TITLE
Bump the version of the debugger_test crate and downgrade the edition to 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "debugger_test"
-version = "0.1.1"
-edition = "2021"
+version = "0.1.2"
+edition = "2018"
 description = """
 Provides a proc macro for writing tests that launch a debugger and run commands while verifying the output.
 """

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -58,7 +58,7 @@ impl Display for Debugger {
 fn find_cdb() -> anyhow::Result<OsString> {
     let pf86 = env::var_os("ProgramFiles(x86)")
         .or_else(|| env::var_os("ProgramFiles"))
-        .expect("msg");
+        .expect("must be able to find the default installation directory for cdb.");
     let cdb_arch = if cfg!(target_arch = "x86") {
         "x86"
     } else if cfg!(target_arch = "x86_64") {


### PR DESCRIPTION
A lot of the crates that this crate should be used for are still targeting the 2018 Rust edition. Keeping this at the 2021 edition will cause it to be unusable in those crates.