### PR TITLE
Update and cleanup API and implementations to support Rust 1.45.0 MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019]
-        rust-toolchain: [stable, nightly]
+        rust-toolchain: [stable, nightly, 1.45.0]
     steps:
 
     - name: Checkout repository

--- a/debugger_test_parser/tests/test.rs
+++ b/debugger_test_parser/tests/test.rs
@@ -4,7 +4,7 @@ use debugger_test_parser::parse;
 fn verify_expected_failure(result: anyhow::Result<()>, expected_err_msg: &str) {
     let error = result
         .expect_err(format!("Expected error message missing: `{}`.", expected_err_msg).as_str());
-    assert_eq!(expected_err_msg, format!("{error}"));
+    assert_eq!(expected_err_msg, format!("{}", error));
 }
 
 /// Test parsing empty debugger output.
@@ -60,9 +60,7 @@ fn test_trim_expected_contents() {
     "#,
     );
 
-    let expected_contents = vec![
-        "        var1 = 0"
-    ];
+    let expected_contents = vec!["        var1 = 0"];
     parse(output, expected_contents).expect("able to parse output.");
 }
 

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -33,7 +33,7 @@ impl FromStr for DebuggerType {
     fn from_str(s: &str) -> Result<DebuggerType, Self::Err> {
         let debugger = s.to_lowercase();
         for debugger_type in DebuggerType::iter() {
-            if debugger == format!("{debugger_type}") {
+            if debugger == format!("{}", debugger_type) {
                 return anyhow::Ok(debugger_type);
             }
         }
@@ -112,7 +112,7 @@ pub fn get_debugger(debugger_type: &DebuggerType) -> anyhow::Result<Debugger> {
                     .arg(version_arg)
                     .output()?
             }
-            error_kind => anyhow::bail!("{error_kind}"),
+            error_kind => anyhow::bail!("{}", io::Error::from(error_kind)),
         },
     };
 

--- a/src/debugger_script.rs
+++ b/src/debugger_script.rs
@@ -2,13 +2,14 @@ pub fn create_debugger_script(fn_name: &String, debugger_commands: &Vec<&str>) -
     let mut debugger_script = String::new();
 
     // Add an inital breakpoint for the test function.
-    debugger_script.push_str(format!("bm *!*::{}\n", fn_name).as_str());
-
-    // Run the debugger to the start of the test.
-    debugger_script.push_str("g\n");
+    // Also add a breakpoint at the end of the test function which quits the debugger.
+    debugger_script.push_str(format!("bm *!*::{} \"bp /1 @$ra \\\"qd\\\" \"\n", fn_name).as_str());
 
     // Add the user specified breakpoints.
     debugger_script.push_str("bm *!*::__break \"gu\"\n");
+
+    // Run the debugger to the start of the test.
+    debugger_script.push_str("g\n");
     debugger_script.push_str("bl\n");
 
     // Run the debugger to the first user set breakpoint.
@@ -20,7 +21,7 @@ pub fn create_debugger_script(fn_name: &String, debugger_commands: &Vec<&str>) -
         debugger_script.push_str(format!(".echo end_debugger_command_{}\n", i).as_str());
     }
 
-    // Be sure to quit the debugger after running all commands.
+    // Quit and detach the debugger
     debugger_script.push_str("qd\n");
 
     debugger_script
@@ -31,9 +32,9 @@ fn test_debugger_script_empty() {
     let test_name = String::from("test1");
     let debugger_commands = vec![];
     let debugger_script = create_debugger_script(&test_name, &debugger_commands);
-    let expected = r#"bm *!*::test1
-g
+    let expected = r#"bm *!*::test1 "bp /1 @$ra \"qd\" "
 bm *!*::__break "gu"
+g
 bl
 g
 qd
@@ -47,9 +48,9 @@ fn test_debugger_script() {
     let test_name = String::from("test1");
     let debugger_commands = vec!["dv", "g", ".nvlist"];
     let debugger_script = create_debugger_script(&test_name, &debugger_commands);
-    let expected = r#"bm *!*::test1
-g
+    let expected = r#"bm *!*::test1 "bp /1 @$ra \"qd\" "
 bm *!*::__break "gu"
+g
 bl
 g
 .echo start_debugger_command_0

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,9 +9,7 @@ fn test_empty_commands() {
 }
 
 #[debugger_test(debugger = "cdb", commands = ".nvlist", expected_statements = "")]
-fn test_no_expectations() {
-    __break();
-}
+fn test_no_expectations() {}
 
 #[debugger_test(
     debugger = "cdb",


### PR DESCRIPTION
Update and cleanup API and implementations to support Rust 1.45.0 as the MSRV. Also update the CI pipeline to test against Rust 1.45.0 to ensure regressions are not introduced.