### PR TITLE
Bump up the version of the debugger test crate.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-latest]
         rust-toolchain: [stable, nightly, 1.45.0]
+        include:
+          - os: ubuntu-latest
+            rust-toolchain: stable
+
     steps:
 
     - name: Checkout repository
@@ -39,7 +43,7 @@ jobs:
     - name: Run debugger_test test suite
       run: cargo test --package debugger_test -- --test-threads=1
     - name: Run debugger_test_parser test suite
-      run: cargo test --package debugger_test_parser --manifest-path debugger_test_parser\Cargo.toml
+      run: cargo test --package debugger_test_parser --manifest-path debugger_test_parser/Cargo.toml
 
   rustfmt:
     name: rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
 # Each test attaches a debugger to the test process so there
 # can not be another debugger attached to the current test process.
     - name: Run debugger_test test suite
-      run: cargo test --package debugger_test -- --test-threads=1
+      run: cargo test --package debugger_test -- --test-threads=1 --no-capture
     - name: Run debugger_test_parser test suite
       run: cargo test --package debugger_test_parser --manifest-path debugger_test_parser/Cargo.toml
 
   rustfmt:
     name: rustfmt
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debugger_test"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 description = """
 Provides a proc macro for writing tests that launch a debugger and run commands while verifying the output.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ The proc macro attribute will generate a test function that will do the followin
 Based on the debugger specified via the `#[debugger_test]` attribute, the path used to launch the debugger will
 be one of the following:
 
-1. If the environment variable `debugger_type`_DEBUGGER_DIR is set, the proc macro attribute will combine this directory with the name of the debugger executable
-2. The default installation directory for the given debugger if the debugger exists at that path
+1. If the environment variable, _debugger_type_ _DEBUGGER_DIR is set, i.e. `CDB_DEBUGGER_DIR`, the proc macro attribute will try to launch the debugger from this directory
+2. The default installation directory for the given debugger if it exists at that path
 3. Invoking the executable directly, i.e. `cdb` or `cdb.exe` depending on the OS
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ The proc macro attribute will generate a test function that will do the followin
 5. Run all of the user specified commands and exit the debugger
 6. Parse the debugger output using the `debugger_test_parser` crate and verify all the `expected_statements` were found
 
+Based on the debugger specified via the `#[debugger_test]` attribute, the path used to launch the debugger will
+be one of the following:
+
+1. If the environment variable `debugger_type`_DEBUGGER_DIR is set, the proc macro attribute will combine this directory with the name of the debugger executable
+2. The default installation directory for the given debugger if the debugger exists at that path
+3. Invoking the executable directly, i.e. `cdb` or `cdb.exe` depending on the OS
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,8 +141,7 @@ pub fn debugger_test(attr: TokenStream, item: TokenStream) -> TokenStream {
                             let mut debugger_stdout = String::new();
                             let mut debugger_stdout_file = std::fs::File::open(&debugger_stdout_path)?;
                             debugger_stdout_file.read_to_string(&mut debugger_stdout)?;
-
-                            panic!("Failed to launch CDB: {}\n{}\n{}\n", error.to_string(), debugger_stderr, debugger_stdout);
+                            return Err(std::boxed::Box::from(format!("Failed to launch CDB: {}\n{}\n{}\n", error.to_string(), debugger_stderr, debugger_stdout)));
                         }
                 }
             );
@@ -206,7 +205,7 @@ pub fn debugger_test(attr: TokenStream, item: TokenStream) -> TokenStream {
                         let mut debugger_stderr = String::new();
                         let mut debugger_stderr_file = std::fs::File::open(&debugger_stderr_path)?;
                         debugger_stderr_file.read_to_string(&mut debugger_stderr)?;
-                        panic!("Debugger failed with {}.\n{}\n{}\n", status, debugger_stderr, debugger_stdout);
+                        return Err(std::boxed::Box::from(format!("Debugger failed with {}.\n{}\n{}\n", status, debugger_stderr, debugger_stdout)));
                     }
 
                     println!("Debugger stdout:\n{}\n", &debugger_stdout);


### PR DESCRIPTION
Add support for reading an environment variable for finding the path to a specific debugger as well as default fallbacks. Update the README file to include this information.

Bump up the version of the debugger_test crate