### PR TITLE
Bump up the version of the debugger_test crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,14 @@ jobs:
     name: test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [windows-2019]
+        os: [windows-latest]
         rust-toolchain: [stable, nightly, 1.45.0]
+        include:
+          - os: ubuntu-latest
+            rust-toolchain: stable
+
     steps:
 
     - name: Checkout repository
@@ -37,13 +42,13 @@ jobs:
 # Each test attaches a debugger to the test process so there
 # can not be another debugger attached to the current test process.
     - name: Run debugger_test test suite
-      run: cargo test --package debugger_test -- --test-threads=1
+      run: cargo test --package debugger_test -- --test-threads=1 --nocapture
     - name: Run debugger_test_parser test suite
-      run: cargo test --package debugger_test_parser --manifest-path debugger_test_parser\Cargo.toml
+      run: cargo test --package debugger_test_parser --manifest-path debugger_test_parser/Cargo.toml
 
   rustfmt:
     name: rustfmt
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         os: [windows-latest]
         rust-toolchain: [stable, nightly, 1.45.0]
-        include:
-          - os: ubuntu-latest
-            rust-toolchain: stable
 
     steps:
 
@@ -33,18 +30,16 @@ jobs:
         override: true
 
     - name: Basic build
-      run: cargo build --verbose
-
-    - name: Build docs
-      run: cargo doc --verbose
+      run: cargo build
 
 # Be sure the debugger tests DO NOT run in parallel.
 # Each test attaches a debugger to the test process so there
 # can not be another debugger attached to the current test process.
-    - name: Run debugger_test test suite
-      run: cargo test --package debugger_test -- --test-threads=1 --nocapture
     - name: Run debugger_test_parser test suite
       run: cargo test --package debugger_test_parser --manifest-path debugger_test_parser/Cargo.toml
+
+    - name: Run debugger_test test suite
+      run: cargo test --package debugger_test -- --test-threads=1 --nocapture
 
   rustfmt:
     name: rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         os: [windows-latest]
         rust-toolchain: [stable, nightly, 1.45.0]
+        include:
+          - os: ubuntu-latest
+            rust-toolchain: stable
 
     steps:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debugger_test"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 description = """
 Provides a proc macro for writing tests that launch a debugger and run commands while verifying the output.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ The proc macro attribute will generate a test function that will do the followin
 Based on the debugger specified via the `#[debugger_test]` attribute, the path used to launch the debugger will
 be one of the following:
 
-1. If the environment variable `debugger_type`_DEBUGGER_DIR is set, the proc macro attribute will combine this directory with the name of the debugger executable
-2. The default installation directory for the given debugger if the debugger exists at that path
+1. If the environment variable, _debugger_type_ _DEBUGGER_DIR is set, i.e. `CDB_DEBUGGER_DIR`, the proc macro attribute will try to launch the debugger from this directory
+2. The default installation directory for the given debugger if it exists at that path
 3. Invoking the executable directly, i.e. `cdb` or `cdb.exe` depending on the OS
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ The proc macro attribute will generate a test function that will do the followin
 5. Run all of the user specified commands and exit the debugger
 6. Parse the debugger output using the `debugger_test_parser` crate and verify all the `expected_statements` were found
 
+Based on the debugger specified via the `#[debugger_test]` attribute, the path used to launch the debugger will
+be one of the following:
+
+1. If the environment variable `debugger_type`_DEBUGGER_DIR is set, the proc macro attribute will combine this directory with the name of the debugger executable
+2. The default installation directory for the given debugger if the debugger exists at that path
+3. Invoking the executable directly, i.e. `cdb` or `cdb.exe` depending on the OS
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ pub fn debugger_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             // Start the debugger and run the debugger commands.
             let mut child = #debugger_command_line;
 
-            // Wait for the debugger to attach
+            // Wait for the debugger to launch
             // On Windows, use the IsDebuggerPresent API to check if a debugger is present
             // for the current process. https://docs.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-isdebuggerpresent
             #[cfg(windows)]
@@ -191,8 +191,7 @@ pub fn debugger_test(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             }
 
-            // If not on Windows, wait 5 seconds for the debugger to attach.
-            #[cfg(not(windows))]
+            // Wait 3 seconds to ensure the debugger is in control of the process.
             std::thread::sleep(std::time::Duration::from_secs(3));
 
             // Call the test function.


### PR DESCRIPTION
Add support for reading an environment variable for finding the path to a specific debugger as well as default fallbacks. Update the README file to include this information.

Bump up the version of the debugger_test crate to 0.1.4