### PR TITLE
Fix bug that would incorrectly pass a debugger test and bump up the version of the debugger_test crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debugger_test"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2018"
 description = """
 Provides a proc macro for writing tests that launch a debugger and run commands while verifying the output.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ proc-macro = true
 anyhow = "1.0.40"
 log = "0.4.17"
 quote = "1.0.20"
-strum = { version = "0.24", features = ["derive"] }
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -3,14 +3,13 @@ use std::ffi::OsString;
 use std::fmt::Display;
 use std::path::PathBuf;
 use std::str::FromStr;
-use strum::{EnumIter, IntoEnumIterator};
 
 #[cfg(windows)]
 pub static EXECUTABLE_EXTENSION: &str = ".exe";
 #[cfg(not(windows))]
 pub static EXECUTABLE_EXTENSION: &str = "";
 
-#[derive(Debug, EnumIter)]
+#[derive(Debug)]
 pub enum DebuggerType {
     Cdb,
 }
@@ -30,12 +29,10 @@ impl FromStr for DebuggerType {
     /// Attempts to parse a string into a DebuggerType
     fn from_str(s: &str) -> Result<DebuggerType, Self::Err> {
         let debugger = s.to_lowercase();
-        for debugger_type in DebuggerType::iter() {
-            if debugger == format!("{}", debugger_type) {
-                return anyhow::Ok(debugger_type);
-            }
+        match debugger.as_str() {
+            "cdb" => Ok(DebuggerType::Cdb),
+            _ => anyhow::bail!("Invalid debugger type option: `{}`.", s),
         }
-        anyhow::bail!("Invalid debugger type option: `{}`.", s)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,10 +216,6 @@ pub fn debugger_test(attr: TokenStream, item: TokenStream) -> TokenStream {
                     }
 
                     println!("Debugger stdout:\n{}\n", &debugger_stdout);
-
-                    // Verify the expected contents of the debugger output.
-                    let expected_statements = vec![#(#expected_statements),*];
-                    debugger_test_parser::parse(debugger_stdout, expected_statements)?;
                 },
                 None => {
                     // Force kill the debugger process if it has not exited yet.
@@ -231,6 +227,10 @@ pub fn debugger_test(attr: TokenStream, item: TokenStream) -> TokenStream {
                     println!("Debugger stdout:\n{}\n", &debugger_stdout);
                 }
             }
+
+            // Verify the expected contents of the debugger output.
+            let expected_statements = vec![#(#expected_statements),*];
+            debugger_test_parser::parse(debugger_stdout, expected_statements)?;
 
             #[cfg(windows)]
             unsafe {


### PR DESCRIPTION
There was a bug in the way debugger tests were being evaluated. If a debugger was force quit, the output would not be parsed, and the tests would be marked as passing.

Fix the bug and bump up the version of the debugger_test crate to 0.1.5.