### PR TITLE
Update extern stdcall to extern system due to latest rustc warnings.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        rust-toolchain: [stable, nightly, 1.45.0]
+        rust-toolchain: [stable, nightly, 1.65.0]
         include:
           - os: ubuntu-latest
             rust-toolchain: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debugger_test"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2018"
 description = """
 Provides a proc macro for writing tests that launch a debugger and run commands while verifying the output.
@@ -12,6 +12,7 @@ repository = "https://github.com/microsoft/rust_debugger_test"
 license = "MIT OR Apache-2.0"
 keywords = ["debugger", "cdb", "natvis", "debugger_visualizer"]
 exclude = ["/.github/*"]
+rust-version = "1.65.0"
 
 [lib]
 proc-macro = true

--- a/debugger_test_parser/Cargo.toml
+++ b/debugger_test_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debugger_test_parser"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2018"
 description = """
 Provides a library for parsing the output of a debugger and verifying the contents.
@@ -11,6 +11,7 @@ homepage = "https://github.com/microsoft/rust_debugger_test/debugger_test_parser
 repository = "https://github.com/microsoft/rust_debugger_test/debugger_test_parser"
 license = "MIT OR Apache-2.0"
 keywords = ["debugger", "cdb", "natvis", "debugger_visualizer"]
+rust-version = "1.65.0"
 
 [dependencies]
 anyhow = "1.0.58"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ pub fn debugger_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             // On Windows, use the IsDebuggerPresent API to check if a debugger is present
             // for the current process. https://docs.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-isdebuggerpresent
             #[cfg(windows)]
-            extern "stdcall" {
+            extern "system" {
                 fn IsDebuggerPresent() -> i32;
             };
             #[cfg(windows)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -37,13 +37,13 @@ fn test_commands_with_expectations() {
     __break();
 
     a += 5;
-    assert_eq!(a, 5);
     __break();
+    assert_eq!(a, 5);
 
     let mut b = 25;
     __break();
 
     b -= 15;
-    assert_eq!(b, 10);
     __break();
+    assert_eq!(b, 10);
 }


### PR DESCRIPTION
The latest Rust complier has started emitting a warning for the usage of `extern "stdcall"`. The debugger test crate was using this in the definition of a proc-macro which has started surfacing compiler warnings for customers.

The suggested solution is to use `extern "system"` instead as this translates to `stdcall` on x86 and `C` for everything else.

Reformatted the tests to set breakpoints before the last usage of the variable since the variables that would no longer be used would be optimized away leading to test failures.

Bump the version of the `debugger_test` crate to `0.2.0`

Fixes [issue 14](https://github.com/microsoft/rust_debugger_test/issues/14).